### PR TITLE
Issue 57: Add "-fork" option

### DIFF
--- a/src/main/java/io/pravega/perf/PerfStats.java
+++ b/src/main/java/io/pravega/perf/PerfStats.java
@@ -16,6 +16,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.locks.LockSupport;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -38,7 +39,7 @@ public class PerfStats {
     final private int messageSize;
     final private int windowInterval;
     final private ConcurrentLinkedQueue<TimeStamp> queue;
-    final private ForkJoinPool executor;
+    final private ExecutorService executor;
 
     @GuardedBy("this")
     private Future<Void> ret;

--- a/src/main/java/io/pravega/perf/PerfStats.java
+++ b/src/main/java/io/pravega/perf/PerfStats.java
@@ -67,13 +67,13 @@ public class PerfStats {
         }
     }
 
-    public PerfStats(String action, int reportingInterval, int messageSize, String csvFile) {
+    public PerfStats(String action, int reportingInterval, int messageSize, String csvFile, ExecutorService executor) {
         this.action = action;
         this.messageSize = messageSize;
         this.windowInterval = reportingInterval;
         this.csvFile = csvFile;
+        this.executor = executor;
         this.queue = new ConcurrentLinkedQueue<>();
-        this.executor = new ForkJoinPool(1);
         this.ret = null;
     }
 

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -284,7 +284,7 @@ public class PravegaPerfTest {
             if (commandline.hasOption("fork")) {
                 fork = Boolean.parseBoolean(commandline.getOptionValue("fork"));
             } else {
-                fork = false;
+                fork = true;
             }
 
             if (commandline.hasOption("throughput")) {

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -321,7 +321,7 @@ public class PravegaPerfTest {
             if (fork) {
                 executor = new ForkJoinPool(threadCount);
             } else {
-                executor = Executors.newScheduledThreadPool(threadCount);
+                executor = Executors.newFixedThreadPool(threadCount);
             }
 
             if (recreate) {

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Performance benchmark for Pravega.
@@ -102,7 +103,7 @@ public class PravegaPerfTest {
             System.exit(0);
         }
 
-        final ForkJoinPool executor = new ForkJoinPool();
+        final ExecutorService executor = new ForkJoinPool();
 
         try {
             final List<WriterWorker> producers = perfTest.getProducers();

--- a/src/main/java/io/pravega/perf/WriterWorker.java
+++ b/src/main/java/io/pravega/perf/WriterWorker.java
@@ -194,7 +194,7 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
 
         for (int i = 0; (time - startTime) < msToRun; i++) {
             time = System.currentTimeMillis();
-            byte[] bytes = timeBuffer.putLong(0, System.currentTimeMillis()).array();
+            byte[] bytes = timeBuffer.putLong(0, time).array();
             System.arraycopy(bytes, 0, payload, 0, bytes.length);
             writeData(payload);
                 /*


### PR DESCRIPTION
**Change log description**  
A new option "-fork" option is added; by default it is set o True; if it set to false, then new fixed thread pool is used.

**Purpose of the change**  
Fixes #57 

**What the code does**  
when user supplies -fork false; conventional thread pool is used; otherwise fork join pool is used.

Signed-off-by: Keshava Munegowda <keshava.munegowda@dell.com>